### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/gr-foo/docs/doxygen/doxyxml/base.py
+++ b/gr-foo/docs/doxygen/doxyxml/base.py
@@ -35,13 +35,13 @@ from generated import compound
 
 class Base(object):
 
-    class Duplicate(StandardError):
+    class Duplicate(Exception):
         pass
 
-    class NoSuchMember(StandardError):
+    class NoSuchMember(Exception):
         pass
 
-    class ParsingError(StandardError):
+    class ParsingError(Exception):
         pass
 
     def __init__(self, parse_data, top=None):
@@ -94,7 +94,7 @@ class Base(object):
         for cls in self.mem_classes:
             if cls.can_parse(mem):
                 return cls
-        raise StandardError(("Did not find a class for object '%s'." \
+        raise Exception(("Did not find a class for object '%s'." \
                                  % (mem.get_name())))
 
     def convert_mem(self, mem):
@@ -102,10 +102,10 @@ class Base(object):
             cls = self.get_cls(mem)
             converted = cls.from_parse_data(mem, self.top)
             if converted is None:
-                raise StandardError('No class matched this object.')
+                raise Exception('No class matched this object.')
             self.add_ref(converted)
             return converted
-        except StandardError, e:
+        except Exception as e:
             print e
 
     @classmethod

--- a/gr-foo/docs/doxygen/doxyxml/base.py
+++ b/gr-foo/docs/doxygen/doxyxml/base.py
@@ -24,6 +24,7 @@ A base class is created.
 Classes based upon this are used to make more user-friendly interfaces
 to the doxygen xml docs than the generated classes provide.
 """
+from __future__ import print_function
 
 import os
 import pdb
@@ -106,7 +107,7 @@ class Base(object):
             self.add_ref(converted)
             return converted
         except Exception as e:
-            print e
+            print(e)
 
     @classmethod
     def includes(cls, inst):

--- a/gr-foo/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-foo/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):
@@ -4221,7 +4221,7 @@ class codelineType(GeneratedsSuper):
         if attrs.get('lineno'):
             try:
                 self.lineno = int(attrs.get('lineno').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (lineno): %s' % exp)
         if attrs.get('refkind'):
             self.refkind = attrs.get('refkind').value
@@ -4504,12 +4504,12 @@ class referenceType(GeneratedsSuper):
         if attrs.get('endline'):
             try:
                 self.endline = int(attrs.get('endline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (endline): %s' % exp)
         if attrs.get('startline'):
             try:
                 self.startline = int(attrs.get('startline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (startline): %s' % exp)
         if attrs.get('refid'):
             self.refid = attrs.get('refid').value
@@ -4627,17 +4627,17 @@ class locationType(GeneratedsSuper):
         if attrs.get('bodystart'):
             try:
                 self.bodystart = int(attrs.get('bodystart').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodystart): %s' % exp)
         if attrs.get('line'):
             try:
                 self.line = int(attrs.get('line').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (line): %s' % exp)
         if attrs.get('bodyend'):
             try:
                 self.bodyend = int(attrs.get('bodyend').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodyend): %s' % exp)
         if attrs.get('bodyfile'):
             self.bodyfile = attrs.get('bodyfile').value
@@ -6778,12 +6778,12 @@ class docTableType(GeneratedsSuper):
         if attrs.get('rows'):
             try:
                 self.rows = int(attrs.get('rows').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (rows): %s' % exp)
         if attrs.get('cols'):
             try:
                 self.cols = int(attrs.get('cols').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (cols): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
@@ -7108,7 +7108,7 @@ class docHeadingType(GeneratedsSuper):
         if attrs.get('level'):
             try:
                 self.level = int(attrs.get('level').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (level): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.TEXT_NODE:

--- a/gr-foo/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-foo/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:44:25 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -8283,7 +8289,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-foo/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-foo/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:43:54 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -462,7 +468,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-foo/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-foo/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):

--- a/gr-foo/docs/doxygen/doxyxml/text.py
+++ b/gr-foo/docs/doxygen/doxyxml/text.py
@@ -49,7 +49,7 @@ def description_bit(obj):
     elif is_string(obj):
         return obj
     else:
-        raise StandardError('Expecting a string or something with content, content_ or value attribute')
+        raise Exception('Expecting a string or something with content, content_ or value attribute')
     # If this bit is a paragraph then add one some line breaks.
     if hasattr(obj, 'name') and obj.name == 'para':
         result += "\n\n"

--- a/gr-foo/docs/doxygen/swig_doc.py
+++ b/gr-foo/docs/doxygen/swig_doc.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     # Parse command line options and set up doxyxml.
     err_msg = "Execute using: python swig_doc.py xml_path outputfilename"
     if len(sys.argv) != 3:
-        raise StandardError(err_msg)
+        raise Exception(err_msg)
     xml_path = sys.argv[1]
     swigdocfilename = sys.argv[2]
     di = DoxyIndex(xml_path)

--- a/gr-foo/docs/doxygen/swig_doc.py
+++ b/gr-foo/docs/doxygen/swig_doc.py
@@ -26,6 +26,7 @@ The file instructs SWIG to transfer the doxygen comments into the
 python docstrings.
 
 """
+from __future__ import print_function
 
 import sys
 
@@ -228,7 +229,7 @@ def make_swig_interface_file(di, swigdocfilename, custom_output=None):
 
     output = "\n\n".join(output)
 
-    swig_doc = file(swigdocfilename, 'w')
+    swig_doc = open(swigdocfilename, 'w')
     swig_doc.write(output)
     swig_doc.close()
 

--- a/gr-foo/python/__init__.py
+++ b/gr-foo/python/__init__.py
@@ -31,9 +31,9 @@ try:
     from dl import RTLD_GLOBAL as _RTLD_GLOBAL
 except ImportError:
     try:
-	from DLFCN import RTLD_GLOBAL as _RTLD_GLOBAL
+        from DLFCN import RTLD_GLOBAL as _RTLD_GLOBAL
     except ImportError:
-	pass
+        pass
 
 if _RTLD_GLOBAL != 0:
     _dlopenflags = sys.getdlopenflags()

--- a/gr-ieee802-11/docs/doxygen/doxyxml/base.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/base.py
@@ -35,13 +35,13 @@ from generated import compound
 
 class Base(object):
 
-    class Duplicate(StandardError):
+    class Duplicate(Exception):
         pass
 
-    class NoSuchMember(StandardError):
+    class NoSuchMember(Exception):
         pass
 
-    class ParsingError(StandardError):
+    class ParsingError(Exception):
         pass
 
     def __init__(self, parse_data, top=None):
@@ -94,7 +94,7 @@ class Base(object):
         for cls in self.mem_classes:
             if cls.can_parse(mem):
                 return cls
-        raise StandardError(("Did not find a class for object '%s'." \
+        raise Exception(("Did not find a class for object '%s'." \
                                  % (mem.get_name())))
 
     def convert_mem(self, mem):
@@ -102,10 +102,10 @@ class Base(object):
             cls = self.get_cls(mem)
             converted = cls.from_parse_data(mem, self.top)
             if converted is None:
-                raise StandardError('No class matched this object.')
+                raise Exception('No class matched this object.')
             self.add_ref(converted)
             return converted
-        except StandardError, e:
+        except Exception as e:
             print e
 
     @classmethod

--- a/gr-ieee802-11/docs/doxygen/doxyxml/base.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/base.py
@@ -24,6 +24,7 @@ A base class is created.
 Classes based upon this are used to make more user-friendly interfaces
 to the doxygen xml docs than the generated classes provide.
 """
+from __future__ import print_function
 
 import os
 import pdb
@@ -106,7 +107,7 @@ class Base(object):
             self.add_ref(converted)
             return converted
         except Exception as e:
-            print e
+            print(e)
 
     @classmethod
     def includes(cls, inst):

--- a/gr-ieee802-11/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):
@@ -4221,7 +4221,7 @@ class codelineType(GeneratedsSuper):
         if attrs.get('lineno'):
             try:
                 self.lineno = int(attrs.get('lineno').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (lineno): %s' % exp)
         if attrs.get('refkind'):
             self.refkind = attrs.get('refkind').value
@@ -4504,12 +4504,12 @@ class referenceType(GeneratedsSuper):
         if attrs.get('endline'):
             try:
                 self.endline = int(attrs.get('endline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (endline): %s' % exp)
         if attrs.get('startline'):
             try:
                 self.startline = int(attrs.get('startline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (startline): %s' % exp)
         if attrs.get('refid'):
             self.refid = attrs.get('refid').value
@@ -4627,17 +4627,17 @@ class locationType(GeneratedsSuper):
         if attrs.get('bodystart'):
             try:
                 self.bodystart = int(attrs.get('bodystart').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodystart): %s' % exp)
         if attrs.get('line'):
             try:
                 self.line = int(attrs.get('line').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (line): %s' % exp)
         if attrs.get('bodyend'):
             try:
                 self.bodyend = int(attrs.get('bodyend').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodyend): %s' % exp)
         if attrs.get('bodyfile'):
             self.bodyfile = attrs.get('bodyfile').value
@@ -6778,12 +6778,12 @@ class docTableType(GeneratedsSuper):
         if attrs.get('rows'):
             try:
                 self.rows = int(attrs.get('rows').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (rows): %s' % exp)
         if attrs.get('cols'):
             try:
                 self.cols = int(attrs.get('cols').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (cols): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
@@ -7108,7 +7108,7 @@ class docHeadingType(GeneratedsSuper):
         if attrs.get('level'):
             try:
                 self.level = int(attrs.get('level').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (level): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.TEXT_NODE:

--- a/gr-ieee802-11/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:44:25 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -8283,7 +8289,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-ieee802-11/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:43:54 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -462,7 +468,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-ieee802-11/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):

--- a/gr-ieee802-11/docs/doxygen/doxyxml/text.py
+++ b/gr-ieee802-11/docs/doxygen/doxyxml/text.py
@@ -49,7 +49,7 @@ def description_bit(obj):
     elif is_string(obj):
         return obj
     else:
-        raise StandardError('Expecting a string or something with content, content_ or value attribute')
+        raise Exception('Expecting a string or something with content, content_ or value attribute')
     # If this bit is a paragraph then add one some line breaks.
     if hasattr(obj, 'name') and obj.name == 'para':
         result += "\n\n"

--- a/gr-ieee802-11/docs/doxygen/swig_doc.py
+++ b/gr-ieee802-11/docs/doxygen/swig_doc.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     # Parse command line options and set up doxyxml.
     err_msg = "Execute using: python swig_doc.py xml_path outputfilename"
     if len(sys.argv) != 3:
-        raise StandardError(err_msg)
+        raise Exception(err_msg)
     xml_path = sys.argv[1]
     swigdocfilename = sys.argv[2]
     di = DoxyIndex(xml_path)

--- a/gr-ieee802-11/docs/doxygen/swig_doc.py
+++ b/gr-ieee802-11/docs/doxygen/swig_doc.py
@@ -26,6 +26,7 @@ The file instructs SWIG to transfer the doxygen comments into the
 python docstrings.
 
 """
+from __future__ import print_function
 
 import sys
 
@@ -228,7 +229,7 @@ def make_swig_interface_file(di, swigdocfilename, custom_output=None):
 
     output = "\n\n".join(output)
 
-    swig_doc = file(swigdocfilename, 'w')
+    swig_doc = open(swigdocfilename, 'w')
     swig_doc.write(output)
     swig_doc.close()
 

--- a/gr-ieee802-11/python/__init__.py
+++ b/gr-ieee802-11/python/__init__.py
@@ -23,9 +23,9 @@ try:
     from dl import RTLD_GLOBAL as _RTLD_GLOBAL
 except ImportError:
     try:
-	from DLFCN import RTLD_GLOBAL as _RTLD_GLOBAL
+        from DLFCN import RTLD_GLOBAL as _RTLD_GLOBAL
     except ImportError:
-	pass
+        pass
 
 if _RTLD_GLOBAL != 0:
     _dlopenflags = sys.getdlopenflags()
@@ -45,4 +45,3 @@ from utils import *
 if _RTLD_GLOBAL != 0:
     sys.setdlopenflags(_dlopenflags)      # Restore original flags
 # ----------------------------------------------------------------
-

--- a/gr-ieee802-11/python/build_utils.py
+++ b/gr-ieee802-11/python/build_utils.py
@@ -29,7 +29,7 @@ from build_utils_codes import *
 # set srcdir to the directory that contains Makefile.am
 try:
     srcdir = os.environ['srcdir']
-except KeyError, e:
+except KeyError as e:
     srcdir = "."
 srcdir = srcdir + '/'
 
@@ -39,7 +39,7 @@ try:
         do_makefile = False
     else:
         do_makefile = True
-except KeyError, e:
+except KeyError as e:
     do_makefile = False
 
 # set do_sources to either true or false dependeing on the environment
@@ -48,7 +48,7 @@ try:
         do_sources = False
     else:
         do_sources = True
-except KeyError, e:
+except KeyError as e:
     do_sources = True
 
 name_dict = {}
@@ -105,8 +105,7 @@ def output_ifile_include (dirname):
     if do_sources:
         f = open ('%s_generated.i' % (dirname,), 'w')
         f.write ('//\n// This file is machine generated.  All edits will be overwritten\n//\n')
-        files = name_dict.setdefault ('i', [])
-        files.sort ()
+        files = sorted(name_dict.setdefault ('i', []))
         f.write ('%{\n')
         for file in files:
             f.write ('#include <%s>\n' % (file[0:-1] + 'h',))
@@ -115,8 +114,7 @@ def output_ifile_include (dirname):
             f.write ('%%include <%s>\n' % (file,))
 
 def output_subfrag (f, ext):
-    files = name_dict.setdefault (ext, [])
-    files.sort ()
+    files = sorted(name_dict.setdefault (ext, []))
     f.write ("GENERATED_%s =" % (ext.upper ()))
     for file in files:
         f.write (" \\\n\t%s" % (file,))

--- a/gr-ieee802-11/python/build_utils.py
+++ b/gr-ieee802-11/python/build_utils.py
@@ -125,7 +125,7 @@ def extract_extension (template_name):
     # we return everything between the penultimate . and .t
     mo = re.search (r'\.([a-z]+)\.t$', template_name)
     if not mo:
-        raise ValueError, "Incorrectly formed template_name '%s'" % (template_name,)
+        raise ValueError("Incorrectly formed template_name '%s'" % (template_name,))
     return mo.group (1)
 
 def open_src (name, mode):

--- a/gr-ieee802-11/utils/channels.py
+++ b/gr-ieee802-11/utils/channels.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 channels = [
 ### 11g
 
@@ -88,5 +89,5 @@ for i in range(0, len(channels), 3):
 	freqs.append(channels[i+1])
 
 
-print labels
-print freqs
+print(labels)
+print(freqs)

--- a/gr-ieee802-11/utils/constellations.py
+++ b/gr-ieee802-11/utils/constellations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import numpy as np
 import matplotlib as mpl
@@ -16,7 +17,7 @@ a = np.array(c.points())
 p = np.average(np.abs(a)**2)
 level = .1**.5
 
-print "16-QAM, average power: {0:.4f}".format(p)
+print("16-QAM, average power: {0:.4f}".format(p))
 
 plt.scatter(a.real, a.imag)
 for i, x in enumerate(a):
@@ -39,9 +40,9 @@ rx = np.array(map(lambda x: c.decision_maker_v([x]), noisy_const))
 rx_const = a[rx]
 
 if any(rx != data):
-    print "16-QAM: data does not match."
+    print("16-QAM: data does not match.")
 else:
-    print "16-QAM: points decoded successfully."
+    print("16-QAM: points decoded successfully.")
 
 plt.scatter(a.real, a.imag)
 plt.scatter(noisy_const.real, noisy_const.imag, marker='x')
@@ -61,7 +62,7 @@ a = np.array(c.points())
 p = np.average(np.abs(a)**2)
 level = (1.0/42)**.5
 
-print "64-QAM, average power: {0:.4f}".format(p)
+print("64-QAM, average power: {0:.4f}".format(p))
 
 plt.scatter(a.real, a.imag)
 for i, x in enumerate(a):
@@ -84,9 +85,9 @@ rx = np.array(map(lambda x: c.decision_maker_v([x]), noisy_const))
 rx_const = a[rx]
 
 if any(rx != data):
-    print "16-QAM: data does not match."
+    print("16-QAM: data does not match.")
 else:
-    print "16-QAM: points decoded successfully."
+    print("16-QAM: points decoded successfully.")
 
 plt.scatter(a.real, a.imag)
 plt.scatter(noisy_const.real, noisy_const.imag, marker='x')

--- a/gr-ieee802-11/utils/pilots.py
+++ b/gr-ieee802-11/utils/pilots.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 
+from __future__ import print_function
 polarity = [
 	 1, 1, 1, 1,-1,-1,-1, 1,-1,-1,-1,-1, 1, 1,-1, 1,
 	-1,-1, 1, 1,-1, 1, 1,-1, 1, 1, 1, 1, 1, 1,-1, 1,
@@ -12,9 +13,9 @@ polarity = [
 	-1, 1,-1,-1,-1, 1, 1, 1,-1,-1,-1,-1,-1,-1,-1]
 
 
-print "polarity"
-print tuple((x, x, x, -x) for x in polarity)
+print("polarity")
+print(tuple((x, x, x, -x) for x in polarity))
 
 
-print "pattern"
-print tuple((-21, -7, 7, 21) for x in range(127))
+print("pattern")
+print(tuple((-21, -7, 7, 21) for x in range(127)))

--- a/gr-ieee802-11/utils/sync_words.py
+++ b/gr-ieee802-11/utils/sync_words.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 
+from __future__ import print_function
 short  = tuple([(52**.5/24**.5) * x for x in [0, 0, 0, 0, 0, 0, 0, 0, 1+1j, 0, 0, 0, -1-1j, 0, 0, 0, 1+1j, 0, 0, 0, -1-1j, 0, 0, 0, -1-1j, 0, 0, 0, 1+1j, 0, 0, 0, 0, 0, 0, 0, -1-1j, 0, 0, 0, -1-1j, 0, 0, 0, 1+1j, 0, 0, 0, 1+1j, 0, 0, 0, 1+1j, 0, 0, 0, 1+1j, 0, 0, 0, 0, 0, 0, 0]])
 
 long_norm = tuple([0, 0, 0, 0, 0, 0, 1, 1, -1, -1, 1, 1, -1, 1, -1, 1, 1, 1, 1, 1, 1, -1, -1, 1, 1, -1, 1, -1, 1, 1, 1, 1, 0, 1, -1, -1, 1, 1, -1, 1, -1, 1, -1, -1, -1, -1, -1, 1, 1, -1, -1, 1, -1, 1, -1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
@@ -18,12 +19,12 @@ assert(len(long_norm) == 64)
 assert(len(long_rot)  == 64)
 assert(len(sync)      == 4)
 
-print "power short: " + str(sum([abs(x)**2 for x in short]))
-print "power long: " + str(sum([abs(x)**2 for x in long_norm]))
+print("power short: " + str(sum([abs(x)**2 for x in short])))
+print("power long: " + str(sum([abs(x)**2 for x in long_norm])))
 
-print "sync sequence"
-print sync
-print "len sync: " + str(len(sync))
+print("sync sequence")
+print(sync)
+print("len sync: " + str(len(sync)))
 
 
 

--- a/gr-ros_interface/docs/doxygen/doxyxml/base.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/base.py
@@ -35,13 +35,13 @@ from generated import compound
 
 class Base(object):
 
-    class Duplicate(StandardError):
+    class Duplicate(Exception):
         pass
 
-    class NoSuchMember(StandardError):
+    class NoSuchMember(Exception):
         pass
 
-    class ParsingError(StandardError):
+    class ParsingError(Exception):
         pass
 
     def __init__(self, parse_data, top=None):
@@ -94,7 +94,7 @@ class Base(object):
         for cls in self.mem_classes:
             if cls.can_parse(mem):
                 return cls
-        raise StandardError(("Did not find a class for object '%s'." \
+        raise Exception(("Did not find a class for object '%s'." \
                                  % (mem.get_name())))
 
     def convert_mem(self, mem):
@@ -102,10 +102,10 @@ class Base(object):
             cls = self.get_cls(mem)
             converted = cls.from_parse_data(mem, self.top)
             if converted is None:
-                raise StandardError('No class matched this object.')
+                raise Exception('No class matched this object.')
             self.add_ref(converted)
             return converted
-        except StandardError, e:
+        except Exception as e:
             print e
 
     @classmethod

--- a/gr-ros_interface/docs/doxygen/doxyxml/base.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/base.py
@@ -24,6 +24,7 @@ A base class is created.
 Classes based upon this are used to make more user-friendly interfaces
 to the doxygen xml docs than the generated classes provide.
 """
+from __future__ import print_function
 
 import os
 import pdb
@@ -106,7 +107,7 @@ class Base(object):
             self.add_ref(converted)
             return converted
         except Exception as e:
-            print e
+            print(e)
 
     @classmethod
     def includes(cls, inst):

--- a/gr-ros_interface/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):
@@ -4221,7 +4221,7 @@ class codelineType(GeneratedsSuper):
         if attrs.get('lineno'):
             try:
                 self.lineno = int(attrs.get('lineno').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (lineno): %s' % exp)
         if attrs.get('refkind'):
             self.refkind = attrs.get('refkind').value
@@ -4504,12 +4504,12 @@ class referenceType(GeneratedsSuper):
         if attrs.get('endline'):
             try:
                 self.endline = int(attrs.get('endline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (endline): %s' % exp)
         if attrs.get('startline'):
             try:
                 self.startline = int(attrs.get('startline').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (startline): %s' % exp)
         if attrs.get('refid'):
             self.refid = attrs.get('refid').value
@@ -4627,17 +4627,17 @@ class locationType(GeneratedsSuper):
         if attrs.get('bodystart'):
             try:
                 self.bodystart = int(attrs.get('bodystart').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodystart): %s' % exp)
         if attrs.get('line'):
             try:
                 self.line = int(attrs.get('line').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (line): %s' % exp)
         if attrs.get('bodyend'):
             try:
                 self.bodyend = int(attrs.get('bodyend').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (bodyend): %s' % exp)
         if attrs.get('bodyfile'):
             self.bodyfile = attrs.get('bodyfile').value
@@ -6778,12 +6778,12 @@ class docTableType(GeneratedsSuper):
         if attrs.get('rows'):
             try:
                 self.rows = int(attrs.get('rows').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (rows): %s' % exp)
         if attrs.get('cols'):
             try:
                 self.cols = int(attrs.get('cols').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (cols): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
@@ -7108,7 +7108,7 @@ class docHeadingType(GeneratedsSuper):
         if attrs.get('level'):
             try:
                 self.level = int(attrs.get('level').value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad integer attribute (level): %s' % exp)
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.TEXT_NODE:

--- a/gr-ros_interface/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:44:25 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -8283,7 +8289,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-ros_interface/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -4,11 +4,17 @@
 # Generated Thu Jun 11 18:43:54 2009 by generateDS.py.
 #
 
+from __future__ import print_function
 import sys
 import getopt
 from string import lower as str_lower
 from xml.dom import minidom
 from xml.dom import Node
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 #
 # User methods
@@ -462,7 +468,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/gr-ros_interface/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -19,7 +19,7 @@ from xml.dom import Node
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper:
         def format_string(self, input_data, input_name=''):

--- a/gr-ros_interface/docs/doxygen/doxyxml/text.py
+++ b/gr-ros_interface/docs/doxygen/doxyxml/text.py
@@ -49,7 +49,7 @@ def description_bit(obj):
     elif is_string(obj):
         return obj
     else:
-        raise StandardError('Expecting a string or something with content, content_ or value attribute')
+        raise Exception('Expecting a string or something with content, content_ or value attribute')
     # If this bit is a paragraph then add one some line breaks.
     if hasattr(obj, 'name') and obj.name == 'para':
         result += "\n\n"

--- a/gr-ros_interface/docs/doxygen/swig_doc.py
+++ b/gr-ros_interface/docs/doxygen/swig_doc.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     # Parse command line options and set up doxyxml.
     err_msg = "Execute using: python swig_doc.py xml_path outputfilename"
     if len(sys.argv) != 3:
-        raise StandardError(err_msg)
+        raise Exception(err_msg)
     xml_path = sys.argv[1]
     swigdocfilename = sys.argv[2]
     di = DoxyIndex(xml_path)

--- a/gr-ros_interface/docs/doxygen/swig_doc.py
+++ b/gr-ros_interface/docs/doxygen/swig_doc.py
@@ -26,6 +26,7 @@ The file instructs SWIG to transfer the doxygen comments into the
 python docstrings.
 
 """
+from __future__ import print_function
 
 import sys
 
@@ -228,7 +229,7 @@ def make_swig_interface_file(di, swigdocfilename, custom_output=None):
 
     output = "\n\n".join(output)
 
-    swig_doc = file(swigdocfilename, 'w')
+    swig_doc = open(swigdocfilename, 'w')
     swig_doc.write(output)
     swig_doc.close()
 


### PR DESCRIPTION
Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

__basestring__ and __file()__ were removed in Python 3.